### PR TITLE
Speed up sage_columns() with Arrow's random-access GCS reader

### DIFF
--- a/sage_R/R/sage.R
+++ b/sage_R/R/sage.R
@@ -163,12 +163,34 @@ sage_columns <- function() {
   o <- idx[order(-idx$bytes), , drop = FALSE]
   o <- o[!duplicated(o$country), , drop = FALSE]
   o <- utils::head(o, 6)
+  src <- sub("/$", "", .sage_source())
+  gcs_root <- if (grepl("^gs://", src)) {
+    sub("^gs://", "", src)
+  } else if (grepl("^https://storage.googleapis.com/", src)) {
+    sub("^https://storage.googleapis.com/", "", src)
+  } else NULL
+  # Use Arrow's random-access reader when GCS support is compiled in; otherwise
+  # retain the portable full-download path below.
+  gcs <- if (!is.null(gcs_root)) {
+    tryCatch(
+      arrow::GcsFileSystem$create(anonymous = TRUE),
+      error = function(e) NULL)
+  } else NULL
   cols <- character(0)
   for (i in seq_len(nrow(o))) {
-    tmp <- tempfile(fileext = ".parquet")
-    utils::download.file(.path_to_url(o$path[i]), tmp, mode = "wb", quiet = TRUE)
-    cols <- union(cols, names(arrow::open_dataset(tmp, format = "parquet")))
-    unlink(tmp)
+    part_cols <- if (!is.null(gcs)) {
+      tryCatch(
+        arrow::ParquetFileReader$create(
+          gcs$OpenInputFile(paste0(gcs_root, "/", o$path[i])))$GetSchema()$names,
+        error = function(e) NULL)
+    } else NULL
+    if (is.null(part_cols)) {
+      tmp <- tempfile(fileext = ".parquet")
+      utils::download.file(.path_to_url(o$path[i]), tmp, mode = "wb", quiet = TRUE)
+      part_cols <- names(arrow::open_dataset(tmp, format = "parquet"))
+      unlink(tmp)
+    }
+    cols <- union(cols, part_cols)
   }
   out <- union(c("country", "year"), cols)
   .sage_state$columns <- out


### PR DESCRIPTION
Thanks @noahdasanaike this is great to have in the R ecosystem and facilitates access to really interesting datasets. Below is an easy performance improvement that will speed up the larger downloads during cold start when reading parquet files from gcs. It won't change behaviour for any other http/https host. There shouldn't be any breaking changes or dependencies here.

More broadly - there's already the bones of an R package in the .r file. There's many helpful devtools packages built up over the years that make building up the rest of the package components a breeze, and it's even easier with AI models now. Do you plan to build up a CRAN package here? The `usethis` package largely has [everything](https://usethis.r-lib.org/) you need if you want to set it up manually. If you want to use a coding agent, I have a [skill](https://github.com/dshkol/rpkgdevskill) that will automate that and a bit more based on styles derived from some of the most hardened and well-used packages. 

Happy to use my own tokens and provide PRs based on that if you are interested - I am not looking for any credit here. 


## Summary

This updates `sage_columns()` to use Arrow's random-access GCS reader when the configured source is a `gs://` URI or a `storage.googleapis.com` URL. If GCS support is unavailable or an individual schema read fails, it retains the existing full-download path as a fallback.

The function currently inspects six representative Parquet files totaling about 298.3 MB just to obtain their schemas. Reading the Parquet metadata through `GcsFileSystem` avoids downloading each complete file while preserving the existing API and output.

## Performance

Matched cold-cache runs against the public SAGE archive (three randomized iterations per implementation):

| Implementation | Median | Range |
| --- | ---: | ---: |
| Existing download path | 5.87 s | 5.80-6.00 s |
| Random-access GCS path | 2.63 s | 2.55-2.79 s |

That is about 2.24x faster at the median (roughly 55% lower latency). Warm-cache overhead was effectively unchanged at approximately 4.4 microseconds.

## Validation

- Confirmed identical ordered `sage_columns()` output against the public archive.
- Compared schemas for nine real archive files, including all six production partitions selected by `sage_columns()` and a percent-encoded path.
- Confirmed identical complete `sage_load()` results for Samoa, Bosnia and Herzegovina, and Germany examples.
- Exercised the explicit HTTPS GCS source and the original HTTP fallback path.
- Checked the required GCS and Parquet reader APIs against Arrow 14.0.0, the package's current minimum version.
- Ran `R CMD build` and `R CMD check --no-manual --no-build-vignettes`; results were unchanged from the existing package (three warnings and one note, with no new findings).

Environment: macOS on Apple Silicon, R 4.5.0, arrow 22.0.0.1, microbenchmark 1.5.0.
